### PR TITLE
added GitHub PR/issue templates

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,22 @@
+* **I'm submitting a ...**
+
+  - [ ] bug report
+  - [ ] feature request
+
+* **What is the current behavior?**
+
+
+
+* **If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem** 
+
+
+
+* **What is the expected behavior?**
+
+
+
+* **What is the motivation / use case for changing the behavior?**
+
+
+
+* **Other information** (e.g. detailed explanation, stacktraces, related issues, suggestions how to fix, links for us to have context, eg. stackoverflow, gitter, etc)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+# Description
+
+
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Chore
+
+# Checklist:
+
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] My changes generate no errors


### PR DESCRIPTION
# Description

Added Github templates in to make communication straight forward prior to feature changes.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Chore

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no errors

# Feature Idea

I'm looking to add a feature for a current "You are here" on our map with a simple screenshot that gets uploaded into a "session"; however, after looking at the code I don't see how sessions are being created. I only see how they're rendered to the dom. 

Are you simply creating them in firebase or maybe with a postman push? I might have missed something, but I don't see any auth UI that will allow for creating sessions -- which in turn would allow to add a progression-map to the session overview. 

Currently forking the repo, since I don't have permissions to add PR's on your repo. 